### PR TITLE
Polished New Dish Form UI

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,6 +9,7 @@
         <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_list_feed.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_list_item.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_new_dish.xml" value="0.25" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/com/example/foodie_app/NewDishFragment.kt
+++ b/app/src/main/java/com/example/foodie_app/NewDishFragment.kt
@@ -102,6 +102,12 @@ class NewDishFragment : Fragment() {
             sharedViewModel.addNewDish(newName, newDate, location, notes, photoUri.toString())
             val action = NewDishFragmentDirections.actionNewDishFragmentToListFeedFragment()
             findNavController().navigate(action)
+        } else {
+            // Set error text
+            binding.etDishName.error = getString(R.string.dish_name_validation)
+
+//            // Clear error text
+//            passwordLayout.error = null
         }
     }
 

--- a/app/src/main/res/layout/fragment_new_dish.xml
+++ b/app/src/main/res/layout/fragment_new_dish.xml
@@ -45,17 +45,21 @@
             android:layout_height="wrap_content"
             android:hint="@string/dish_name"
             android:padding="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:paddingBottom="0dp"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/addPicBtn"
+            app:layout_constraintBottom_toTopOf="@+id/tfLocation"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:layout_weight="0">
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etDishName"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:inputType="textAutoComplete|textCapWords"
+                android:singleLine="true"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -68,12 +72,15 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tfDishName">
+            app:layout_constraintTop_toBottomOf="@+id/tfDishName"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etLocation"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:inputType="textAutoComplete|textCapWords"
+                android:singleLine="true"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -99,12 +106,14 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btnDate">
+            app:layout_constraintTop_toBottomOf="@+id/btnDate"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNotes"
                 android:layout_width="match_parent"
-                android:layout_height="100dp" />
+                android:layout_height="100dp"
+                android:singleLine="true"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="content_description_media">Dish</string>
     <string name="add_new_item">Add New Item</string>
     <string name="add_fragment_title">New Dish</string>
+    <string name="dish_name_validation">Must enter a name</string>
 </resources>


### PR DESCRIPTION
Problem: No user feedback when adding a new dish.

Solution: Added name validation message which blocks user from saving a dish with no name. Created single line edit fields to let user skip to next field straight from the keyboard. Changed the styling of the input fields to be more aesthetic.

Result: Better new dish form.

![240835938_379506920446532_2688231842911094626_n (2)](https://user-images.githubusercontent.com/41392379/131221562-4e1dafec-e9be-4162-a6a5-c324164314ba.jpg)
